### PR TITLE
add clock tolerance to conversion delay table

### DIFF
--- a/ads1x15.py
+++ b/ads1x15.py
@@ -22,6 +22,7 @@
 # THE SOFTWARE.
 #
 import utime as time
+import asyncio
 
 _REGISTER_MASK = const(0x03)
 _REGISTER_CONVERT = const(0x00)
@@ -125,6 +126,18 @@ _RATES = (
     _DR_860SPS    # - /860 samples per Second
 )
 
+# Exact conversion delays in ms for the ADS1115 based on the sample rate
+_CONVERSION_DELAYS = (
+        125,  # 8 SPS
+        62.5, # 16 SPS
+        31.25,# 32 SPS
+        15.63,# 64 SPS
+        7.81, # 128 SPS
+        4.0,  # 250 SPS
+        2.1,  # 475 SPS
+        1.16  # 860 SPS
+    )
+
 
 class ADS1115:
     def __init__(self, i2c, address=0x48, gain=1):
@@ -132,6 +145,7 @@ class ADS1115:
         self.address = address
         self.gain = gain
         self.temp2 = bytearray(2)
+        self._lock = asyncio.Lock()
 
     def _write_register(self, register, value):
         self.temp2[0] = value >> 8
@@ -165,6 +179,23 @@ class ADS1115:
         res = self._read_register(_REGISTER_CONVERT)
         return res if res < 32768 else res - 65536
 
+    async def aioread(self, rate=4, channel1=0, channel2=None, delays=_CONVERSION_DELAYS):
+        """Read voltage between a channel and GND or any pair.
+           Non-Blocking approach based on cooperative sleep."""
+        async with self._lock:
+            # with exclusive access to ADC hardware, because it only supports one conversion at a time
+            self._write_register(_REGISTER_CONFIG, (_CQUE_NONE | _CLAT_NONLAT |
+                                 _CPOL_ACTVLOW | _CMODE_TRAD | _RATES[rate] |
+                                 _MODE_SINGLE | _OS_SINGLE | _GAINS[self.gain] |
+                                 _CHANNELS[(channel1, channel2)]))
+
+            # delay from data-sheet + 1 ms margin
+            base_delay = delays[rate] if rate < len(delays) else delays[4]
+            await asyncio.sleep_ms(int(base_delay + 1))
+
+            res = self._read_register(_REGISTER_CONVERT)
+            return res if res < 32768 else res - 65536
+    
     def read_rev(self):
         """Read voltage between a channel and GND. and then start
            the next conversion."""
@@ -234,6 +265,17 @@ class ADS1114(ADS1115):
 
 
 class ADS1015(ADS1115):
+    _CONVERSION_DELAYS_ADS1015 = (
+        7.81, # 128 SPS
+        4.0,  # 250 SPS
+        2.04, # 490 SPS
+        1.09, # 920 SPS
+        0.625,# 1600 SPS
+        0.4,  # 2400 SPS
+        0.3,  # 3300 SPS
+        1.16  # 860 SPS
+    )
+
     def __init__(self, i2c, address=0x48, gain=1):
         super().__init__(i2c, address, gain)
 
@@ -242,6 +284,10 @@ class ADS1015(ADS1115):
 
     def read(self, rate=4, channel1=0, channel2=None):
         return super().read(rate, channel1, channel2) >> 4
+
+    async def aioread(self, rate=4, channel1=0, channel2=None):
+        res = await super().aioread(rate, channel1, channel2, delays=self._CONVERSION_DELAYS_ADS1015)
+        return res >> 4    
 
     def alert_start(self, rate=4, channel1=0, channel2=None, threshold_high=0x400,
         threshold_low=0, latched=False):

--- a/ads1x15.py
+++ b/ads1x15.py
@@ -126,16 +126,16 @@ _RATES = (
     _DR_860SPS    # - /860 samples per Second
 )
 
-# Exact conversion delays in ms for the ADS1115 based on the sample rate
+# Conversion delays in ms for the ADS1115 (including +10% clock tolerance + 1ms margin, rounded up)
 _CONVERSION_DELAYS = (
-        125,  # 8 SPS
-        62.5, # 16 SPS
-        31.25,# 32 SPS
-        15.63,# 64 SPS
-        7.81, # 128 SPS
-        4.0,  # 250 SPS
-        2.1,  # 475 SPS
-        1.16  # 860 SPS
+        139,  # 8 SPS (125ms + 10% + 1ms)
+        70,   # 16 SPS (62.5ms + 10% + 1ms)
+        36,   # 32 SPS (31.25ms + 10% + 1ms)
+        19,   # 64 SPS (15.63ms + 10% + 1ms)
+        10,   # 128 SPS (7.81ms + 10% + 1ms)
+        6,    # 250 SPS (4.0ms + 10% + 1ms)
+        4,    # 475 SPS (2.1ms + 10% + 1ms)
+        3     # 860 SPS (1.16ms + 10% + 1ms)
     )
 
 
@@ -189,9 +189,8 @@ class ADS1115:
                                  _MODE_SINGLE | _OS_SINGLE | _GAINS[self.gain] |
                                  _CHANNELS[(channel1, channel2)]))
 
-            # delay from data-sheet + 1 ms margin
-            base_delay = delays[rate] if rate < len(delays) else delays[4]
-            await asyncio.sleep_ms(int(base_delay + 1))
+            # delay from data-sheet + tolerance
+            await asyncio.sleep_ms(delays[rate])
 
             res = self._read_register(_REGISTER_CONVERT)
             return res if res < 32768 else res - 65536
@@ -266,14 +265,14 @@ class ADS1114(ADS1115):
 
 class ADS1015(ADS1115):
     _CONVERSION_DELAYS_ADS1015 = (
-        7.81, # 128 SPS
-        4.0,  # 250 SPS
-        2.04, # 490 SPS
-        1.09, # 920 SPS
-        0.625,# 1600 SPS
-        0.4,  # 2400 SPS
-        0.3,  # 3300 SPS
-        1.16  # 860 SPS
+        10,   # 128 SPS (7.81ms + 10% + 1ms)
+        6,    # 250 SPS (4.0ms + 10% + 1ms)
+        4,    # 490 SPS (2.04ms + 10% + 1ms)
+        3,    # 920 SPS (1.09ms + 10% + 1ms)
+        2,    # 1600 SPS (0.625ms + 10% + 1ms)
+        2,    # 2400 SPS (0.4ms + 10% + 1ms)
+        2,    # 3300 SPS (0.3ms + 10% + 1ms)
+        3     # 860 SPS (1.16ms + 10% + 1ms)
     )
 
     def __init__(self, i2c, address=0x48, gain=1):

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-﻿# Driver for the ADS1015/ADS1115 Analogue-Digital Converter
+# Driver for the ADS1015/ADS1115 Analogue-Digital Converter
 
 This driver consists mostly of the work of Radomir Dopieralski (@deshipu).
 I added a few functions and changed the existing ones so it matches better
@@ -76,6 +76,13 @@ needed for communication with the ADC, which is about 1 ms on an esp8266
 at 80 MHz. Slower conversion yields in a less noisy result.
 The data sheet figures of the ads1x15 are given for the slowest sample rate.
 The value returned is a signed integer of the raw ADC value. That value can be converted to a voltage with the method raw_to_v().
+
+### adc.aioread()
+```python
+value = await adc.aioread([rate, [channel1[, channel2]]])
+```
+
+Similar to `adc.read()`, but non-blocking. It uses an `asyncio.Lock` to serialize concurrent requests, starts the conversion, and cooperatively sleeps (`await asyncio.sleep_ms`) for the duration of the conversion delay (based on the sample rate) before reading the result.
 
 ###  adc.set_conv and adc.read_rev()
 


### PR DESCRIPTION
fix for the aioread function

that function relies on precomputed delays when waiting for a conversion result

The test done in #16 when this function was introduced ran fine. But when I call aioread for two channels in the context of a larger program the values get mixed up. 

Reason as far as I understand: in the test-program the asyncio scheduler worked laizily, and woke up the aioread function late, so the conversion always was ready.

Now under a higher system load the asyncio scheduler is more active and wakes up tasks more strictly in time. Then the ADC conversion is not always ready (because I did not consider the adc internal clock tolerance in the delay tables).

This PR fixes the delay time computation, taking clock tolerance into account.

I suggest to 
- either commit this fix which means relying on the data sheet. 
- Or revert the aioread addition to the master branch and take some more time to think and decide about a thorough solution. E.g. one could make the aioread function not depend on correctness of precomputed delay by introducing a small loop that reads the "ready" register, and awaits 1ms when not ready. But that incurs the cost of an additional i2c transfer
